### PR TITLE
Update hooks for Jodel 4.6.6

### DIFF
--- a/app/src/main/java/com/jodelXposed/krokofant/hooks/JodelHooks.java
+++ b/app/src/main/java/com/jodelXposed/krokofant/hooks/JodelHooks.java
@@ -26,12 +26,12 @@ import static de.robv.android.xposed.XposedHelpers.*;
 public class JodelHooks {
 
     public static class PhotoEditFragment {
-        public static String Post = "apD";
-        public static String ImageView = "arZ";
+        public static String Post = "arw";
+        public static String ImageView = "arx";
     }
 
     public static class OkClient$2 {
-        public static String InputStream = "CK";
+        public static String InputStream = "CI";
     }
 
     public static class RecyclerPostsAdapter {
@@ -43,7 +43,7 @@ public class JodelHooks {
         /**
          * Add features on ImageView - load custom stored image, adjust ScaleType
          */
-        findAndHookMethod("com.jodelapp.jodelandroidv3.view.PhotoEditFragment", lpparam.classLoader, "zJ", new XC_MethodHook() {
+        findAndHookMethod("com.jodelapp.jodelandroidv3.view.PhotoEditFragment", lpparam.classLoader, "zC", new XC_MethodHook() {
             @Override
             protected void afterHookedMethod(MethodHookParam param) throws Throwable {
 
@@ -109,7 +109,7 @@ public class JodelHooks {
         /**
          * Apply darker shade to OP's posts in a thread
          */
-        findAndHookMethod("com.jodelapp.jodelandroidv3.view.adapter.JodelRepliesAdapter", lpparam.classLoader, "p", List.class, new XC_MethodHook() {
+        findAndHookMethod("com.jodelapp.jodelandroidv3.view.adapter.RecyclerPostsAdapter", lpparam.classLoader, "p", List.class, new XC_MethodHook() {
             @Override
             protected void afterHookedMethod(MethodHookParam param) throws Throwable {
                 List posts = (List) param.args[0];
@@ -246,7 +246,7 @@ public class JodelHooks {
         /**
          * Spoof UID
          */
-        findAndHookMethod("com.jodelapp.jodelandroidv3.utilities.UniqueDeviceIdentifier", lpparam.classLoader, "yt", new XC_MethodHook() {
+        findAndHookMethod("com.jodelapp.jodelandroidv3.utilities.UniqueDeviceIdentifier", lpparam.classLoader, "yr", new XC_MethodHook() {
             @Override
             protected void afterHookedMethod(MethodHookParam param) throws Throwable {
                 xlog("UDI = " + param.getResult());


### PR DESCRIPTION
I just updated the hooks for the current version of Jodel (4.6.6). Tested everything except UID Spoofing, but that should work, if it did so before.
