### PR TITLE
Fix crash on KitKat

### DIFF
--- a/app/src/main/java/com/jodelXposed/utils/Picker.java
+++ b/app/src/main/java/com/jodelXposed/utils/Picker.java
@@ -37,7 +37,6 @@ public class Picker extends AppCompatActivity {
 
         if (ContextCompat.checkSelfPermission(this, (Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED ||
                 ContextCompat.checkSelfPermission(this, (Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-                requestPermissions(,PERMISSION_REQUEST_CODE);
             if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.ACCESS_COARSE_LOCATION) || ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) ) {
                 //we could derp about how stupid the user is for not giving permissions here using an alertdialog or similar...
 				//on alertDialog dismiss:

--- a/app/src/main/java/com/jodelXposed/utils/Picker.java
+++ b/app/src/main/java/com/jodelXposed/utils/Picker.java
@@ -35,18 +35,38 @@ public class Picker extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (!permissionsGranted()){
-                requestPermissions(new String[]{Manifest.permission.ACCESS_COARSE_LOCATION,Manifest.permission.WRITE_EXTERNAL_STORAGE},PERMISSION_REQUEST_CODE);
-            }
-        }
-
-        if (permissionsGranted()){
-            getAction();
-        }
+        if (ContextCompat.checkSelfPermission(this, (Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED ||
+                ContextCompat.checkSelfPermission(this, (Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+                requestPermissions(,PERMISSION_REQUEST_CODE);
+            if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.ACCESS_COARSE_LOCATION) || ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) ) {
+                //we could derp about how stupid the user is for not giving permissions here using an alertdialog or similar...
+				//on alertDialog dismiss:
+				ActivityCompat.requestPermissions(TimetableActivity.this, new String[]{Manifest.permission.ACCESS_COARSE_LOCATION,Manifest.permission.WRITE_EXTERNAL_STORAGE}, PERMISSION_REQUEST_CODE);
+            } else
+                ActivityCompat.requestPermissions(TimetableActivity.this, new String[]{Manifest.permission.ACCESS_COARSE_LOCATION,Manifest.permission.WRITE_EXTERNAL_STORAGE}, PERMISSION_REQUEST_CODE);
+        } else getAction();
 
     }
 
+	@Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
+        switch (requestCode) {
+            case PERMISSION_REQUEST_CODE: {
+				boolean success = true;
+				for (int i = 0; i < grantResults.length; i++)
+					if (grantResults[i] != PackageManager.PERMISSION_GRANTED)
+						success = false;
+				
+                if (success) 
+					getAction();
+                else {
+                    Toast.makeText(getApplicationContext(), "This app needs permissions in order to work", Toast.LENGTH_LONG).show();
+					finish(); //prevent further errors by closing the activity
+                }
+            }
+        }
+    }
+	
     private void getAction(){
         switch (getIntent().getIntExtra("choice",0)){
             case 1:
@@ -76,13 +96,6 @@ public class Picker extends AppCompatActivity {
         intent.putExtra(LocationPickerActivity.LATITUDE, location.getLat());
         intent.putExtra(LocationPickerActivity.LONGITUDE, location.getLng());
         startActivityForResult(intent, PLACEPICKER_REQUEST_CODE);
-    }
-
-
-    @TargetApi(Build.VERSION_CODES.M)
-    private boolean permissionsGranted(){
-        return this.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED
-            && this.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED;
     }
 
     @Override
@@ -117,17 +130,4 @@ public class Picker extends AppCompatActivity {
         }
         finish();
     }
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
-        switch (requestCode) {
-            case PERMISSION_REQUEST_CODE: {
-                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    getAction();
-                }else{
-                    Toast.makeText(getApplicationContext(), "This app needs permissions in order to work", Toast.LENGTH_LONG).show();
-                }
-            }
-        }
-    }
 }
-


### PR DESCRIPTION
You can't add @TargetAPI M to a method and expect it to work on every API version... that's going to throw unknownMethodExceptions.
I added my Permission management and removed the targeted function.

I edited the file in notepad so maybe check it with AndroidStudio again to see if I missed imports.
