### PR TITLE
Fix for Android 4

### DIFF
--- a/app/src/main/java/com/jodelXposed/utils/AnalyticsDisabler.java
+++ b/app/src/main/java/com/jodelXposed/utils/AnalyticsDisabler.java
@@ -11,12 +11,12 @@ import java.util.Map;
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XC_MethodReplacement;
 import de.robv.android.xposed.XposedBridge;
+import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 
 import static de.robv.android.xposed.XposedHelpers.callMethod;
 import static de.robv.android.xposed.XposedHelpers.findAndHookMethod;
 import static de.robv.android.xposed.XposedHelpers.findClass;
-import static de.robv.android.xposed.XposedHelpers.findClassIfExists;
 import static de.robv.android.xposed.XposedHelpers.findMethodBestMatch;
 
 /**
@@ -136,6 +136,15 @@ public class AnalyticsDisabler {
 
         analyticsFrameworks.append("disabling them! Your data belongs to you!");
         Log.d(TAG, analyticsFrameworks.toString());
+    }
+
+    private static Class findClassIfExists(String s, ClassLoader classLoader) {
+        try {
+            Class<?> cls = findClass(s, classLoader);
+            return cls;
+        } catch (XposedHelpers.ClassNotFoundError ex) {
+            return null;
+        }
     }
 
     private void suppressLoggingCalls() {

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <integer name="google_play_services_version">10084000</integer>
-</resources>


### PR DESCRIPTION
The method `findClassIfExists` is not part of my Xposed framework (2.6.1), which makes the initialization of JodelXposed fail. This helper method fixed it for my version.

Second, the value `google_play_services_version` makes the app crash on _JX Change location_ on my phone. I'm not familiar with that option, but a quick google search suggested to delete the field, which worked for me.